### PR TITLE
preloads associations before removing id on update

### DIFF
--- a/lib/alog.ex
+++ b/lib/alog.ex
@@ -164,10 +164,10 @@ defmodule Alog do
         data =
           changeset
           |> Map.get(:data)
+          |> @repo.preload(__MODULE__.__schema__(:associations))
           |> Map.put(:id, nil)
           |> Map.put(:inserted_at, nil)
           |> Map.put(:updated_at, nil)
-          |> @repo.preload(__MODULE__.__schema__(:associations))
 
         changeset
         |> Map.put(:data, data)

--- a/test/update_test.exs
+++ b/test/update_test.exs
@@ -26,5 +26,13 @@ defmodule AlogTest.UpdateTest do
       assert User.get(user.entry_id) |> User.preload(:items) == updated_user
       assert User.get(user.entry_id).postcode == "W2 3EC"
     end
+
+    test "associations remain after update" do
+      {:ok, user, item} = Helpers.seed_data()
+
+      {:ok, updated_user} = user |> User.changeset(%{postcode: "W2 3EC"}) |> User.update()
+
+      assert User.get(user.entry_id) |> User.preload(:items) |> Map.get(:items) |> length == 1
+    end
   end
 end


### PR DESCRIPTION
A small bug I found when implementing the update from #23 in https://github.com/club-soda/club-soda-guide/pull/208

- Preloads associations before removing id from struct, ensuring they remain after update.