### PR TITLE
Add case insensitive option

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Alog.MixProject do
   def project do
     [
       app: :alog,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/get_by_test.exs
+++ b/test/get_by_test.exs
@@ -21,5 +21,19 @@ defmodule AlogTest.GetByTest do
 
       assert User.get_by(postcode: "E2 0SY", name: "Thor") == user
     end
+
+    test "works with map params " do
+      {:ok, user} = %User{} |> User.changeset(Helpers.user_1_params()) |> User.insert()
+
+      assert User.get_by(%{postcode: "E2 0SY", name: "Thor"}) == user
+    end
+
+    test "case_insensitive option" do
+      {:ok, user} = %User{} |> User.changeset(Helpers.user_1_params()) |> User.insert()
+
+      refute User.get_by(name: "thor") == user
+      assert User.get_by([name: "thor"], case_insensitive: true) == user
+      assert User.get_by(%{name: "thor"}, case_insensitive: true) == user
+    end
   end
 end


### PR DESCRIPTION
Allows specifying an option of :case_insensitive for a `get_by` query