### PR TITLE
Configure repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ This module provides some helper functions to make it easy to insert and retriev
   ```
 
   ## Repo
+
+  You can set the repo you want Alog to use in a config file:
+
+  ``` elixir
+ config :alog, Alog,
+    repo: MyApp.Repo
+  ```
   
-  Alog expects your `Repo` to belong to the same base module as the schema.
-  So if your schema is `MyApp.User`, or `MyApp.Accounts.User`, your Repo should be `MyApp.Repo`.
+  If you do not explicitly set a Repo, Alog will try to find it using your application name.
+  So if your app is `MyApp` and your schema is `MyApp.User`, or `MyApp.Accounts.User`, your Repo should be `MyApp.Repo`.
 
   ## Uniqueness
 

--- a/lib/alog.ex
+++ b/lib/alog.ex
@@ -61,7 +61,7 @@ defmodule Alog do
       import Ecto.Query
       import Ecto.Query.API, only: [field: 2]
 
-      @repo __MODULE__ |> Module.split() |> List.first() |> Module.concat("Repo")
+      @repo apply(unquote(__MODULE__), :get_repo, [__MODULE__])
 
       if not Map.has_key?(%__MODULE__{}, :deleted) || not is_boolean(%__MODULE__{}.deleted) do
         raise """
@@ -414,6 +414,18 @@ defmodule Alog do
       end
 
       defoverridable Alog
+    end
+  end
+
+  def get_repo(module) do
+    with config when not is_nil(config) <- Application.get_env(:alog, Alog),
+         repo when not is_nil(repo) <- Keyword.get(config, :repo) do
+    else
+      _ ->
+        module
+        |> Module.split()
+        |> List.first()
+        |> Module.concat("Repo")
     end
   end
 end

--- a/lib/alog.ex
+++ b/lib/alog.ex
@@ -28,8 +28,13 @@ defmodule Alog do
         end
       end
 
-  Alog expects your `Repo` to belong to the same base module as the schema.
-  So if your schema is `MyApp.User`, or `MyApp.Accounts.User`, your Repo should be `MyApp.Repo`.
+  You can set the repo you want Alog to use in a config file:
+
+      config :alog, Alog,
+        repo: MyApp.Repo
+
+  If you do not explicitly set a Repo, Alog will try to find it using your application name.
+  So if your app is `MyApp` and your schema is `MyApp.User`, or `MyApp.Accounts.User`, your Repo should be `MyApp.Repo`.
 
   Any schema that uses Alog must include the fields `:deleted` of type `:boolean` and default false,
   and `:entry_id` of type `:string`.


### PR DESCRIPTION
Allows repo to be set in config.

Alog used to automatically determine the repo name based on the application name it was used in. 
It still does this, but only as a backup if the repo is not explicitly set in a config file.

This allows the repo to be named something other than the default name, and also allows us to use Alog in nested dependencies while still using the repo of the original calling application.