### PR TITLE
Query all

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 config :alog, Alog.Repo,
   username: "postgres",
-  password: "postgres",
-  database: "test_app_dev",
+  password: "docker",
+  database: "routinedb",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox,
   priv: "priv/repo/test_app/"

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 config :alog, Alog.Repo,
   username: "postgres",
-  password: "docker",
-  database: "routinedb",
+  password: "postgres",
+  database: "test_app_dev",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox,
   priv: "priv/repo/test_app/"

--- a/lib/alog/connection.ex
+++ b/lib/alog/connection.ex
@@ -44,7 +44,7 @@ defmodule Alog.Connection do
     else
       subquery = IO.iodata_to_binary(
                   [ "SELECT DISTINCT ON (#{query_data["table_as"]}.\"entry_id\" ) ",
-                    query_data["subquery_fields"], ", #{query_data["table_as"]}.\"deleted\" AS \"delted\"",
+                    query_data["subquery_fields"], ", #{query_data["table_as"]}.\"deleted\" AS \"deleted\"",
                     " FROM ",
                     query_data["table_name"], " AS ", query_data["table_as"],
                     query_data["rest_query"],

--- a/lib/alog/connection.ex
+++ b/lib/alog/connection.ex
@@ -27,7 +27,50 @@ defmodule Alog.Connection do
   defdelegate to_constraints(error_struct), to: EAPC
 
   @impl true
-  defdelegate all(query), to: EAPC
+  def all(query) do
+    iodata_query =  EAPC.all(query)
+
+    # sub =
+    #   from(m in __MODULE__,
+    #     distinct: m.entry_id,
+    #     order_by: [desc: :updated_at],
+    #     select: m
+    #   )
+    #
+    # query = from(m in subquery(sub), where: not m.deleted, select: m)
+
+
+# SELECT
+#   s0."id",
+#   s0."name",
+#   s0."entry_id",
+#   s0."deleted",
+#   s0."inserted_at",
+#   s0."updated_at"
+# FROM
+#   (SELECT DISTINCT ON (d0."entry_id")
+#       d0."id" AS "id"
+#     , d0."name" AS "name"
+#     , d0."entry_id" AS "entry_id"
+#     , d0."deleted" AS "deleted"
+#     , d0."inserted_at" AS "inserted_at"
+#     , d0."updated_at" AS "updated_at"
+#   FROM "drink_types" AS d0
+#   ORDER BY d0."entry_id", d0."updated_at" DESC)
+# AS s0 WHERE (NOT (s0."deleted"))
+
+
+    query = iodata_query
+    |> IO.iodata_to_binary()
+    |> distinct_entry_id()
+
+    IO.inspect query
+    query
+  end
+
+  defp distinct_entry_id("SELECT " <> query) do
+    IO.iodata_to_binary(["SELECT ", "DISTINCT ON (\"entry_id\" ) ", query])
+  end
 
   @impl true
   defdelegate update_all(query, prefix \\ nil), to: EAPC

--- a/lib/alog/connection.ex
+++ b/lib/alog/connection.ex
@@ -68,8 +68,29 @@ defmodule Alog.Connection do
     query
   end
 
-  defp distinct_entry_id("SELECT " <> query) do
-    IO.iodata_to_binary(["SELECT ", "DISTINCT ON (\"entry_id\" ) ", query])
+  # defp distinct_entry_id("SELECT " <> fields <> " FROM " <> table_name <> " AS " <> table_as <> " " <> rest_query) do
+  #
+  #   IO.iodata_to_binary(["SELECT ", "DISTINCT ON (#{table_as}\".entry_id\" ) ", query])
+  # end
+
+  defp distinct_entry_id(query) do
+    query_data = get_query_data(query)
+    if (query_data["table_name"] == "\"schema_migrations\"") do
+      query
+    else
+      IO.iodata_to_binary(
+      [ "SELECT DISTINCT ON (#{query_data["table_as"]}.\"entry_id\" ) ",
+        query_data["fields"],
+        " FROM ",
+        query_data["table_name"], " AS ", query_data["table_as"],
+        query_data["rest_query"]
+    ]
+    )
+    end
+  end
+
+  defp get_query_data(query) do
+    Regex.named_captures(~r/(\bSELECT\b)\s(?<fields>.*)\sFROM\s(?<table_name>.*)\sas\s(?<table_as>.*)(?<rest_query>.*)/i, query)
   end
 
   @impl true

--- a/lib/alog/connection.ex
+++ b/lib/alog/connection.ex
@@ -83,7 +83,8 @@ defmodule Alog.Connection do
         query_data["fields"],
         " FROM ",
         query_data["table_name"], " AS ", query_data["table_as"],
-        query_data["rest_query"]
+        query_data["rest_query"],
+        " ORDER BY #{query_data["table_as"]}.\"entry_id\", #{query_data["table_as"]}.\"inserted_at\" DESC", 
     ]
     )
     end

--- a/test/all_test.exs
+++ b/test/all_test.exs
@@ -1,31 +1,14 @@
 defmodule AlogTest.AllTest do
   use Alog.TestApp.DataCase
 
-  # alias Alog.TestApp.{User, Helpers}
-  #
-  # describe "all/0:" do
-  #   test "succeeds" do
-  #     {:ok, _} = %User{} |> User.changeset(Helpers.user_1_params()) |> User.insert()
-  #     {:ok, _} = %User{} |> User.changeset(Helpers.user_2_params()) |> User.insert()
-  #
-  #     assert length(User.all()) == 2
-  #   end
-  #
-  #   test "does not include old items" do
-  #     {:ok, user} = %User{} |> User.changeset(Helpers.user_1_params()) |> User.insert()
-  #     {:ok, _} = %User{} |> User.changeset(Helpers.user_2_params()) |> User.insert()
-  #     {:ok, _} = user |> User.changeset(%{postcode: "W2 3EC"}) |> User.update()
-  #
-  #     assert length(User.all()) == 2
-  #   end
-  #
-  #   test "all return inserted_at original value" do
-  #     {:ok, user} = %User{} |> User.changeset(Helpers.user_3_params()) |> User.insert()
-  #     {:ok, user_updated} = user |> User.changeset(%{postcode: "W2 3EC"}) |> User.update()
-  #
-  #     [user_all] = User.all()
-  #     assert user_all.inserted_at == user.inserted_at
-  #     assert user_all.postcode == user_updated.postcode
-  #   end
-  # end
+  alias Alog.TestApp.{Comment}
+
+  describe "all/0:" do
+    test "succeeds" do
+      {:ok, _comment} = %Comment{comment: "Hello Rob"}  |> Repo.insert()
+      {:ok, _} = %Comment{comment: "Hello Dan"} |> Repo.insert()
+
+      assert length(Repo.all(Comment)) == 2
+    end
+  end
 end


### PR DESCRIPTION
ref: #40 

This PR is based on #50 (thanks @RobStallion , it's much easier to have a common base :+1: )

When `Repo.all(query)` is called we need to
- [x] order the elements of the query by inserted_at value
- [x] add "distinct on" the entry_id to make sure to get the latest version of the item
- [x] Then with the two added points above, create a subquery and select only the element of these subquery which are not deleted